### PR TITLE
Add support for Livebook running with IPv6 host

### DIFF
--- a/lib/livebook_tools/cli.ex
+++ b/lib/livebook_tools/cli.ex
@@ -216,7 +216,16 @@ defmodule LivebookTools.CLI do
 
   defp ensure_node_started do
     rand_str = :crypto.strong_rand_bytes(16) |> Base.url_encode64(padding: false)
-    node_name = String.to_atom("livebook_tools_#{rand_str}@127.0.0.1")
+
+    host =
+      if System.get_env("ERL_AFLAGS")
+         |> String.contains?("-proto_dist inet6_tcp") do
+        "::1"
+      else
+        "127.0.0.1"
+      end
+
+    node_name = String.to_atom("livebook_tools_#{rand_str}@#{host}")
     Node.start(node_name)
     secret = String.to_atom(System.get_env("LIVEBOOK_COOKIE", "secret"))
     Node.set_cookie(Node.self(), secret)

--- a/lib/livebook_tools/sync.ex
+++ b/lib/livebook_tools/sync.ex
@@ -33,7 +33,15 @@ defmodule LivebookTools.Sync do
       {:ok, names} ->
         discovered_node =
           Enum.find_value(names, fn {name, _port} ->
-            node_name = "#{name}@127.0.0.1" |> String.to_atom()
+            host =
+              if System.get_env("ERL_AFLAGS")
+                 |> String.contains?("-proto_dist inet6_tcp") do
+                "::1"
+              else
+                "127.0.0.1"
+              end
+
+            node_name = "#{name}@#{host}" |> String.to_atom()
             was_connected = Node.list(:connected) |> Enum.member?(node_name)
 
             case Node.connect(node_name) do


### PR DESCRIPTION
This is useful, for example, when Livebook needs to connect to something running on Fly.io.